### PR TITLE
Use source table in find object

### DIFF
--- a/lib/sequel/mapper.rb
+++ b/lib/sequel/mapper.rb
@@ -83,7 +83,11 @@ module Sequel
     end
 
     def find_object(object=nil, key: object.public_send(primary_key))
-      dataset.where(primary_key => key) if key
+      dataset.where(pk_with_table => key) if key
+    end
+
+    def pk_with_table
+      "#{dataset.first_source_table}__#{primary_key}".to_sym
     end
 
     def scope(dataset)

--- a/lib/sequel/mapper/version.rb
+++ b/lib/sequel/mapper/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module Mapper
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
This prevents ambiguous column errors when using joins in the dataset
