### PR TITLE
Allow a block to be passed into where method

### DIFF
--- a/lib/sequel/mapper.rb
+++ b/lib/sequel/mapper.rb
@@ -54,7 +54,11 @@ module Sequel
     def_delegators :dataset, :count, :all, :each, :map, :first, :last, :empty?
     alias :size :count
 
-    %w{where order grep limit}.each do |sc|
+    define_method :where do |*args, &block|
+      scope dataset.public_send(:where, *args, &block)
+    end
+
+    %w{order grep limit}.each do |sc|
       define_method sc do |*args|
         scope dataset.public_send(sc, *args)
       end

--- a/lib/sequel/mapper/version.rb
+++ b/lib/sequel/mapper/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module Mapper
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
This is needed - `sequel` abstracts some of the comparisons into blocks, so we see things like `.where {foo > 10}` in dataset manipulations